### PR TITLE
Version compatibility changes

### DIFF
--- a/mytap-partition.sql
+++ b/mytap-partition.sql
@@ -358,7 +358,7 @@ BEGIN
       FROM `idents1`
       WHERE `ident` NOT IN
         (
-          SELECT COALESCE(`subpartition_name`, `partition_name`)
+          SELECT COALESCE(`subpartition_name` COLLATE utf8_general_ci, `partition_name` COLLATE utf8_general_ci)
           FROM `information_schema`.`partitions`
           WHERE `table_schema` = sname
           AND `table_name` = tname
@@ -383,7 +383,7 @@ BEGIN
       FROM `information_schema`.`partitions`
       WHERE `table_schema` = sname
       AND `table_name` = tname
-      AND COALESCE(`subpartition_name`,`partition_name`) NOT IN 
+      AND COALESCE(`subpartition_name` COLLATE utf8_general_ci,`partition_name` COLLATE utf8_general_ci) NOT IN 
         (
           SELECT `ident`
           FROM `idents2`

--- a/mytap-routines.sql
+++ b/mytap-routines.sql
@@ -486,17 +486,17 @@ RETURNS TEXT
 DETERMINISTIC
 COMMENT 'Check that a particular SQL mode will apply to a named routine within the given schema.'
 BEGIN
+
+  -- this 5.7 list of sql_modes
+  -- should be fine as a test provide it is superset of previous modes
+  -- we're only interesed in the name rather than what it does (which does change)
   DECLARE valid ENUM('REAL_AS_FLOAT','PIPES_AS_CONCAT','ANSI_QUOTES','IGNORE_SPACE',
-    'NOT_USED','ONLY_FULL_GROUP_BY','NO_UNSIGNED_SUBTRACTION','NO_DIR_IN_CREATE',
+      'NOT_USED','ONLY_FULL_GROUP_BY','NO_UNSIGNED_SUBTRACTION','NO_DIR_IN_CREATE',
       'POSTGRESQL','ORACLE','MSSQL','DB2','MAXDB','NO_KEY_OPTIONS','NO_TABLE_OPTIONS',
       'NO_FIELD_OPTIONS','MYSQL323','MYSQL40','ANSI','NO_AUTO_VALUE_ON_ZERO','NO_BACKSLASH_ESCAPES',
       'STRICT_TRANS_TABLES','STRICT_ALL_TABLES','NO_ZERO_IN_DATE','NO_ZERO_DATE','INVALID_DATES',
       'ERROR_FOR_DIVISION_BY_ZERO','TRADITIONAL','NO_AUTO_CREATE_USER','HIGH_NOT_PRECEDENCE',
       'NO_ENGINE_SUBSTITUTION','PAD_CHAR_TO_FULL_LENGTH');
-
-  DECLARE EXIT HANDLER FOR 1264
-    RETURN CONCAT(ok(FALSE, description), '\n',
-      diag(CONCAT('Unrecoverable Error - Strict Mode should be disabled when importing this ', rtype)));
 
   DECLARE EXIT HANDLER FOR 1265 -- invalid assignment to enum
     RETURN CONCAT(ok(FALSE,description), '\n',

--- a/mytap-table-56.sql
+++ b/mytap-table-56.sql
@@ -1,0 +1,83 @@
+USE tap;
+
+-- 5.6 version file
+
+
+/****************************************************************************/
+-- CHECK FOR SCHEMA CHANGES
+-- Get the SHA-1 from the table definition and it's constituent schema objects 
+-- to for a simple test for changes. Excludes partitioning since the names might
+-- change over the course of time through normal DLM operations.
+-- Allows match against partial value to save typing as
+-- 8 characters will give 16^8 combinations.
+
+DELIMITER //
+
+DROP FUNCTION IF EXISTS _table_sha1 //
+CREATE FUNCTION _table_sha1(sname VARCHAR(64), tname VARCHAR(64))
+RETURNS CHAR(40)
+DETERMINISTIC
+BEGIN
+  DECLARE ret CHAR(40);
+
+  SELECT SHA1(GROUP_CONCAT(sha)) INTO ret
+  FROM 
+    (   
+      (SELECT SHA1( -- COLUMNS
+        GROUP_CONCAT(
+          SHA1(
+            -- > 5.6 version
+	    CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`column_name`,
+              `ordinal_position`,`column_default`,`is_nullable`,`data_type`,
+              `character_set_name`,`character_maximum_length`,`character_octet_length`,
+              `numeric_precision`,`numeric_scale`,`datetime_precision`,`collation_name`,
+              `column_type`,`column_key`,`extra`,`privileges`,`column_comment`)
+          ))) sha
+      FROM `information_schema`.`columns`
+      WHERE `table_schema` = sname
+      AND `table_name` = tname
+      ORDER BY `table_name` ASC,`column_name` ASC)
+  UNION ALL
+      (SELECT SHA1( -- CONSTRAINTS
+        GROUP_CONCAT(
+          SHA1(
+            CONCAT_WS('',`constraint_catalog`,`constraint_schema`,`constraint_name`,
+            `unique_constraint_catalog`,`unique_constraint_schema`,`unique_constraint_name`,
+            `match_option`,`update_rule`,`delete_rule`,`table_name`,`referenced_table_name`)
+      ))) sha
+      FROM `information_schema`.`referential_constraints`
+      WHERE `constraint_schema` = sname
+      AND `table_name` = tname
+      ORDER BY `table_name` ASC,`constraint_name` ASC)
+  UNION ALL
+      (SELECT SHA1( -- INDEXES
+        GROUP_CONCAT(
+          SHA1(
+            CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`non_unique`,
+              `index_schema`,`index_name`,`seq_in_index`,`column_name`,`collation`,`cardinality`,
+              `sub_part`,`packed`,`nullable`,`index_type`,`comment`,`index_comment`)
+      ))) sha
+      FROM `information_schema`.`statistics`
+      WHERE `table_schema` = sname
+      AND `table_name` = tname
+      ORDER BY `table_name` ASC,`index_name` ASC,`seq_in_index` ASC)
+  UNION ALL
+      (SELECT SHA1( -- TRIGGERS
+        GROUP_CONCAT(
+          SHA1(
+           CONCAT_WS('',`trigger_catalog`,`trigger_schema`,`trigger_name`,`event_manipulation`,
+            `event_object_catalog`,`event_object_schema`,`event_object_table`,`action_order`,
+            `action_condition`,`action_statement`,`action_orientation`,`action_timing`,
+            `action_reference_old_table`,`action_reference_new_table`,`action_reference_old_row`,
+            `action_reference_new_row`,`sql_mode`,`definer`,`database_collation`)
+      ))) sha
+      FROM `information_schema`.`triggers`
+      WHERE `trigger_schema` = sname
+      AND `event_object_table` = tname
+      ORDER BY `event_object_table` ASC,`trigger_name` ASC)
+  ) objects;
+
+  RETURN COALESCE(ret, NULL);
+END //
+
+DELIMITER ;

--- a/mytap-table-57.sql
+++ b/mytap-table-57.sql
@@ -1,0 +1,84 @@
+USE tap;
+
+-- 5.7 version file
+
+
+/****************************************************************************/
+-- CHECK FOR SCHEMA CHANGES
+-- Get the SHA-1 from the table definition and it's constituent schema objects 
+-- to for a simple test for changes. Excludes partitioning since the names might
+-- change over the course of time through normal DLM operations.
+-- Allows match against partial value to save typing as
+-- 8 characters will give 16^8 combinations.
+
+
+DELIMITER //
+
+DROP FUNCTION IF EXISTS _table_sha1 //
+CREATE FUNCTION _table_sha1(sname VARCHAR(64), tname VARCHAR(64))
+RETURNS CHAR(40)
+DETERMINISTIC
+BEGIN
+  DECLARE ret CHAR(40);
+
+  SELECT SHA1(GROUP_CONCAT(sha)) INTO ret
+  FROM 
+    (   
+      (SELECT SHA1( -- COLUMNS 5.7 version
+        GROUP_CONCAT(
+          SHA1(
+             CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`column_name`,
+              `ordinal_position`,`column_default`,`is_nullable`,`data_type`,
+              `character_set_name`,`character_maximum_length`,`character_octet_length`,
+              `numeric_precision`,`numeric_scale`,`datetime_precision`,`collation_name`,
+              `column_type`,`column_key`,`extra`,`privileges`,`column_comment`,
+              `generation_expression`)
+          ))) sha
+      FROM `information_schema`.`columns`
+      WHERE `table_schema` = sname
+      AND `table_name` = tname
+      ORDER BY `table_name` ASC,`column_name` ASC)
+  UNION ALL
+      (SELECT SHA1( -- CONSTRAINTS
+        GROUP_CONCAT(
+          SHA1(
+            CONCAT_WS('',`constraint_catalog`,`constraint_schema`,`constraint_name`,
+            `unique_constraint_catalog`,`unique_constraint_schema`,`unique_constraint_name`,
+            `match_option`,`update_rule`,`delete_rule`,`table_name`,`referenced_table_name`)
+      ))) sha
+      FROM `information_schema`.`referential_constraints`
+      WHERE `constraint_schema` = sname
+      AND `table_name` = tname
+      ORDER BY `table_name` ASC,`constraint_name` ASC)
+  UNION ALL
+      (SELECT SHA1( -- INDEXES
+        GROUP_CONCAT(
+          SHA1(
+            CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`non_unique`,
+              `index_schema`,`index_name`,`seq_in_index`,`column_name`,`collation`,`cardinality`,
+              `sub_part`,`packed`,`nullable`,`index_type`,`comment`,`index_comment`)
+      ))) sha
+      FROM `information_schema`.`statistics`
+      WHERE `table_schema` = sname
+      AND `table_name` = tname
+      ORDER BY `table_name` ASC,`index_name` ASC,`seq_in_index` ASC)
+  UNION ALL
+      (SELECT SHA1( -- TRIGGERS
+        GROUP_CONCAT(
+          SHA1(
+           CONCAT_WS('',`trigger_catalog`,`trigger_schema`,`trigger_name`,`event_manipulation`,
+            `event_object_catalog`,`event_object_schema`,`event_object_table`,`action_order`,
+            `action_condition`,`action_statement`,`action_orientation`,`action_timing`,
+            `action_reference_old_table`,`action_reference_new_table`,`action_reference_old_row`,
+            `action_reference_new_row`,`sql_mode`,`definer`,`database_collation`)
+      ))) sha
+      FROM `information_schema`.`triggers`
+      WHERE `trigger_schema` = sname
+      AND `event_object_table` = tname
+      ORDER BY `event_object_table` ASC,`trigger_name` ASC)
+  ) objects;
+
+  RETURN COALESCE(ret, NULL);
+END //
+
+DELIMITER ;

--- a/mytap-table.sql
+++ b/mytap-table.sql
@@ -1,3 +1,5 @@
+USE tap;
+
 DELIMITER //
 
 /****************************************************************************/
@@ -319,6 +321,9 @@ RETURNS CHAR(40)
 DETERMINISTIC
 BEGIN
   DECLARE ret CHAR(40);
+  DECLARE ver INT;
+
+  SET ver = (SELECT tap.mysql_version());
 
   SELECT SHA1(GROUP_CONCAT(sha)) INTO ret
   FROM 
@@ -326,13 +331,12 @@ BEGIN
       (SELECT SHA1( -- COLUMNS
         GROUP_CONCAT(
           SHA1(
-            CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`column_name`,
+	     CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`column_name`,
               `ordinal_position`,`column_default`,`is_nullable`,`data_type`,
               `character_set_name`,`character_maximum_length`,`character_octet_length`,
-              `numeric_precision`,`numeric_scale`,`datetime_precision`,`collation_name`,
-              `column_type`,`column_key`,`extra`,`privileges`,`column_comment`,
-              `generation_expression`)
-      ))) sha
+              `numeric_precision`,`numeric_scale`,`collation_name`,
+              `column_type`,`column_key`,`extra`,`privileges`,`column_comment`)
+          ))) sha
       FROM `information_schema`.`columns`
       WHERE `table_schema` = sname
       AND `table_name` = tname
@@ -353,7 +357,7 @@ BEGIN
       (SELECT SHA1( -- INDEXES
         GROUP_CONCAT(
           SHA1(
-            CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`index_name`,`non_unique`,
+            CONCAT_WS('',`table_catalog`,`table_schema`,`table_name`,`non_unique`,
               `index_schema`,`index_name`,`seq_in_index`,`column_name`,`collation`,`cardinality`,
               `sub_part`,`packed`,`nullable`,`index_type`,`comment`,`index_comment`)
       ))) sha

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SQLHOST=localhost;
+SQLPORT=3306;
+
 while [[ "$#" > 0 ]]; do
     case $1 in
 	-u|--user)
@@ -10,6 +13,14 @@ while [[ "$#" > 0 ]]; do
 	    SQLPASS="$2"
 	    shift
 	    ;;
+	-h|--host)
+	    SQLHOST="$2"
+	    shift
+	    ;;
+	-P|--port)
+	    SQLPORT="$2"
+	    shift
+	    ;;
 	-f|--filter)
 	    FILTER="$2"
 	    shift
@@ -17,11 +28,13 @@ while [[ "$#" > 0 ]]; do
 	-h|--help)
 	    cat << EOF
 Usage:
- runtest.sh [options]
+ runtests.sh [options]
 
 Options:
  -u, --user           MySQL username
  -p, --password       MySQL password
+ -P, --port           MySQL port
+ -h, --host           MySQL host
  -f, --filter         <matching|eq|moretap|todo|utils|charset|collation|column|constraint|engine|event|index|partition|routines|table|trigger|schemata|user|view>
 EOF
 	   exit 1 
@@ -33,18 +46,49 @@ EOF
     shift;
 done
 
+
+MYSQLOPTS="--disable-pager --batch --raw --skip-column-names --unbuffered"
+
 if [[ $SQLUSER != '' ]] && [[ $SQLPASS != '' ]]; then
-  MYSLOPTS="-u$SQLUSER -p$SQLPASS --disable-pager --batch --raw --skip-column-names --unbuffered"
-else
-  MYSLOPTS="--disable-pager --batch --raw --skip-column-names --unbuffered"
+  MYSQLOPTS="$MYSQLOPTS -u$SQLUSER -p$SQLPASS"
+fi
+
+if [[ $SQLHOST != 'localhost' ]]; then
+  MYSQLOPTS="$MYSQLOPTS --host $SQLHOST"
+fi
+
+if [[ $SQLPORT != '3306' ]]; then
+  MYSQLOPTS="$MYSQLOPTS --port $SQLPORT"
 fi
 
 if [[ $FILTER == '' ]]; then
   FILTER=0
 fi
 
+MYVER=`mysql $MYSQLOPTS --execute "SELECT @@global.version" | awk -F'.' '{print $1$2}'`;
+
+# import the full package before running the tests
+# you can't use a wildcard with the source command so all version specific files need
+# to be separately listed
+
 echo "============= updating tap ============="
-mysql $MYSLOPTS --execute 'source ./mytap.sql'
+echo "Importing myTAP base"
+mysql $MYSQLOPTS --execute 'source ./mytap.sql'
+
+if [[ $MYVER == '56' ]]; then
+    echo "Importing Version 5.6 patches";
+    mysql $MYSQLOPTS --execute 'source ./mytap-table-56.sql';
+fi
+
+if [[ $MYVER == '57' ]]; then
+    echo "Importing Version 5.7 patches";
+    mysql $MYSQLOPTS --execute 'source ./mytap-table-57.sql';
+fi
+
+if [[ $MYVER == '80' ]]; then
+    echo "Importing Version 8.0 patches";
+    mysql $MYSQLOPTS --execute 'source ./mytap-table-80.sql';
+fi
 
 if [[ $FILTER != 0 ]]; then
   echo "============= filtering ============="
@@ -53,96 +97,96 @@ fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "matching" ]]; then
   echo "============= matching ============="
-  mysql $MYSLOPTS --database tap --execute 'source tests/matching.my'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/matching.my'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "eq" ]]; then
   echo "============= eq ============="
-  mysql $MYSLOPTS --database tap --execute 'source tests/eq.my'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/eq.my'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "moretap" ]]; then
   echo "============= moretap ============="
-  mysql $MYSLOPTS --database tap --execute 'source tests/moretap.my'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/moretap.my'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "todotap" ]]; then
   echo "============= todotap ============="
-  mysql $MYSLOPTS --database tap --execute 'source tests/todotap.my'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/todotap.my'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "utils" ]]; then
   echo "============= utils ============="
-  mysql $MYSLOPTS --database tap --execute 'source tests/utils.my'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/utils.my'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "charset" ]]; then
   echo "============= character sets ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-charset.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-charset.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "collation" ]]; then
   echo "============= collations ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-collation.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-collation.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "column" ]]; then
   echo "============= columns ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-column.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-column.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "constraint" ]]; then
   echo "============= cconstraints ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-constraint.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-constraint.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "engine" ]]; then
   echo "============= engines ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-engine.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-engine.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "event" ]]; then
   echo "============= events ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-event.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-event.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "index" ]]; then
   echo "============= indexes ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-index.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-index.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "partition" ]]; then
   echo "============= partitions ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-partition.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-partition.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "routines" ]]; then
   echo "============= routines ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-routines.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-routines.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "schemata" ]]; then
   echo "============= schemas ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-schemata.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-schemata.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "table" ]]; then
   echo "============= tables ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-table.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-table.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "trigger" ]]; then
   echo "============= triggers ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-trigger.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-trigger.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "user" ]]; then
   echo "============= users ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-user.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-user.sql'
 fi
 
 if [[ $FILTER == 0 ]] || [[ $FILTER =~ "view" ]]; then
   echo "============= views ============"
-  mysql $MYSLOPTS --database tap --execute 'source tests/test-mytap-view.sql'
+  mysql $MYSQLOPTS --database tap --execute 'source tests/test-mytap-view.sql'
 fi
 

--- a/tests/test-mytap-routines.sql
+++ b/tests/test-mytap-routines.sql
@@ -12,7 +12,7 @@ and disgnostic message simultaneously.
 
 -- required for sql_mode test
 SET @mode = (SELECT @@session.sql_mode);
-SET @@session.sql_mode = 'STRICT_ALL_TABLES';
+SET @@session.sql_mode = 'REAL_AS_FLOAT';
 
 
 BEGIN;
@@ -732,7 +732,7 @@ SELECT tap.check_test(
 
 -- routine_has_sql_mode(sname VARCHAR(64), rname VARCHAR(64), rtype VARCHAR(64), smode VARCHAR(8192), description TEXT)
 SELECT tap.check_test(
-    tap.routine_has_sql_mode('taptest', 'intFunction', 'FUNCTION', 'STRICT_ALL_TABLES', ''),
+    tap.routine_has_sql_mode('taptest', 'intFunction', 'FUNCTION', 'REAL_AS_FLOAT', ''),
     true,
     'routine_has_sql_mode() correct specification',
     null,

--- a/tests/test-mytap-trigger.sql
+++ b/tests/test-mytap-trigger.sql
@@ -1,5 +1,5 @@
 /*
-TAP tests for column functions
+TAP tests for trigger functions
 
 */
 
@@ -43,10 +43,12 @@ FOR EACH ROW set @tmp := 1;
 DROP TRIGGER IF EXISTS `taptest`.`othertrigger`;
 
 CREATE TRIGGER `taptest`.`othertrigger`
-BEFORE INSERT ON `taptest`.`sometab`
+BEFORE UPDATE ON `taptest`.`sometab`
 FOR EACH ROW set @tmp := 1;
 
-
+-- NB
+-- Needs more than 1 trigger defined on the same event to properly test
+-- trigger_order_is()
 
 /***************************************************************************/
 -- has_trigger(sname VARCHAR(64), tname VARCHAR(64), trgr VARCHAR(64), description TEXT)
@@ -252,52 +254,71 @@ SELECT tap.check_test(
 /***************************************************************************/
 -- trigger_order_is(sname VARCHAR(64), tname VARCHAR(64), trgr VARCHAR(64), seq BIGINT, description TEXT)
 
-SELECT tap.check_test(
-  tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 1, ''),
-  true,
-  'trigger_order_is() with correct specification',
-  null,
-  null,
-  0
-);
+SELECT CASE WHEN tap.mysql_version() > 507000 THEN
+  tap.check_test(
+    tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 1, ''),
+    true,
+    'trigger_order_is() with correct specification',
+    null,
+    null,
+    0
+  )
+ELSE
+  tap.skip(1,"trigger_order_is() requires MySQL version > 5.7")
+END;
 
-SELECT tap.check_test(
-  tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 2, ''),
-  false,
-  'trigger_order_is() with incorrect specification',
-  null,
-  null,
-  0
-);
+SELECT CASE WHEN tap.mysql_version() > 507000 THEN
+  tap.check_test(
+    tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 2, ''),
+    false,
+    'trigger_order_is() with incorrect specification',
+    null,
+    null,
+    0
+  )
+ELSE
+  tap.skip(1,"trigger_order_is() requires MySQL version > 5.7")
+END;
 
 
-SELECT tap.check_test(
-  tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 1, ''),
-  true,
-  'trigger_order_is() default description',
-  'Trigger sometab.testtrigger should have Action Order 1',
-  null,
-  0
-);
+SELECT CASE WHEN tap.mysql_version() > 507000 THEN
+  tap.check_test(
+    tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 1, ''),
+    true,
+    'trigger_order_is() default description',
+    'Trigger sometab.testtrigger should have Action Order 1',
+    null,
+    0
+  )
+ELSE
+  tap.skip(2,"trigger_order_is() requires MySQL version > 5.7")
+END;
 
-SELECT tap.check_test(
-  tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 1, 'desc'),
-  true,
-  'trigger_order_is() description supplied',
-  'desc',
-  null,
-  0
-);
+SELECT CASE WHEN tap.mysql_version() > 507000 THEN
+  tap.check_test(
+    tap.trigger_order_is('taptest', 'sometab', 'testtrigger', 1, 'desc'),
+    true,
+    'trigger_order_is() description supplied',
+    'desc',
+    null,
+    0
+  )
+ELSE
+  tap.skip(2,"trigger_order_is() tests require MySQL version > 5.7")
+END;
 
-SELECT tap.check_test(
-  tap.trigger_order_is('taptest', 'sometab', 'nonexistent', 1, ''),
-  false,
-  'trigger_order_is() nonexistent trigger diagnostic',
-  null,
-  'Trigger sometab.nonexistent does not exist',
-  0
-);
-
+SELECT CASE WHEN tap.mysql_version() > 507000 THEN
+  tap.check_test(
+    tap.trigger_order_is('taptest', 'sometab', 'nonexistent', 1, ''),
+    false,
+    'trigger_order_is() nonexistent trigger diagnostic',
+    null,
+    'Trigger sometab.nonexistent does not exist',
+    0
+  )
+ELSE
+  tap.skip(2,"trigger_order_is() requires MySQL version > 5.7")
+END;
 
 
 /***************************************************************************/


### PR DESCRIPTION
Following commits are tested against 5.5, 5.6 and 5.7
Added multi-version testing which skips unsupported features to allow tests to run from a single file
Use version-aware dynamic SQL for test setup to allow different information_schema versions to be exercised
Added separate version specific files to allow for changes in information_schema table definitions
Add host and port parameters to runtest.sh (makes testing in docker much easier), ensure correct version patches are applied before tests are run