### PR TITLE
query global variables in pre and post 5.7.6 versions

### DIFF
--- a/mytap-global-57.sql
+++ b/mytap-global-57.sql
@@ -1,5 +1,5 @@
 /************************************************************************************/
-
+-- 5.7.6 and upwards
 USE tap;
 -- Check the state of GLOBAL variables
 
@@ -13,7 +13,7 @@ BEGIN
   DECLARE ret VARCHAR(1024);
 
   SELECT `variable_value` INTO ret
-  FROM `information_schema`.`global_variables`
+  FROM `performance_schema`.`global_variables`
   WHERE `variable_name` = var;
 
   RETURN COALESCE(ret, 0);
@@ -29,9 +29,9 @@ BEGIN
     SET description = CONCAT('@@GLOBAL.' , var, ' should be correctly set');
   END IF;
 
- IF NOT tap.mysql_version() < 507006 THEN
+  IF NOT tap.mysql_version() >= 507006 THEN
     RETURN CONCAT(ok(FALSE, description),'\n',
-      diag (CONCAT('This version of MySQL requires a later version of this function')));
+      diag (CONCAT('This version of MySQL requires the previous version of this function')));
   END IF;
 
   RETURN eq(_global_var(var), want, description);

--- a/runtests.sh
+++ b/runtests.sh
@@ -65,7 +65,12 @@ if [[ $FILTER == '' ]]; then
   FILTER=0
 fi
 
-MYVER=`mysql $MYSQLOPTS --execute "SELECT @@global.version" | awk -F'.' '{print $1$2}'`;
+MYVER1=`mysql $MYSQLOPTS --execute "SELECT @@global.version" | awk -F'-' '{print $1}' | awk -F'.' '{print $1 * 100000 }'`;
+MYVER2=`mysql $MYSQLOPTS --execute "SELECT @@global.version" | awk -F'-' '{print $1}' | awk -F'.' '{print $2 * 1000 }'`;
+MYVER3=`mysql $MYSQLOPTS --execute "SELECT @@global.version" | awk -F'-' '{print $1}' | awk -F'.' '{print $3}'`;
+
+
+MYVER=$(($MYVER1+$MYVER2+$MYVER3));
 
 # import the full package before running the tests
 # you can't use a wildcard with the source command so all version specific files need
@@ -74,18 +79,24 @@ MYVER=`mysql $MYSQLOPTS --execute "SELECT @@global.version" | awk -F'.' '{print 
 echo "============= updating tap ============="
 echo "Importing myTAP base"
 mysql $MYSQLOPTS --execute 'source ./mytap.sql'
+mysql $MYSQLOPTS --execute 'source ./mytap-global.sql';
 
-if [[ $MYVER == '56' ]]; then
+if [[ $MYVER -gt 506000 ]]; then
     echo "Importing Version 5.6 patches";
     mysql $MYSQLOPTS --execute 'source ./mytap-table-56.sql';
 fi
 
-if [[ $MYVER == '57' ]]; then
+if [[ $MYVER -gt 507000 ]]; then
     echo "Importing Version 5.7 patches";
     mysql $MYSQLOPTS --execute 'source ./mytap-table-57.sql';
 fi
 
-if [[ $MYVER == '80' ]]; then
+if [[ $MYVER -gt 507006 ]]; then
+    echo "Importing Version 5.7.6 patches";
+    mysql $MYSQLOPTS --execute 'source ./mytap-global-57.sql';
+fi
+
+if [[ $MYVER -gt 800000 ]]; then
     echo "Importing Version 8.0 patches";
     mysql $MYSQLOPTS --execute 'source ./mytap-table-80.sql';
 fi

--- a/tests/test-mytap-table.sql
+++ b/tests/test-mytap-table.sql
@@ -43,8 +43,7 @@ BEGIN
       myNum   INT(8) DEFAULT 24,
       myat    TIMESTAMP DEFAULT NOW(),
       plain   INT,
-      virt    INT AS (plain * 3) VIRTUAL,
-      KEY(name)
+      virt    INT AS (plain * 3) VIRTUAL
       ) ENGINE=INNODB, CHARACTER SET utf8, COLLATE utf8_general_ci';
   WHEN myver > 506000 THEN -- fractional seconds stored in 5.6
     SET @sql1 = '

--- a/tests/test-mytap-table.sql
+++ b/tests/test-mytap-table.sql
@@ -43,7 +43,8 @@ BEGIN
       myNum   INT(8) DEFAULT 24,
       myat    TIMESTAMP DEFAULT NOW(),
       plain   INT,
-      virt    INT AS (plain * 3) VIRTUAL
+      virt    INT AS (plain * 3) VIRTUAL,
+      KEY(name)
       ) ENGINE=INNODB, CHARACTER SET utf8, COLLATE utf8_general_ci';
   WHEN myver > 506000 THEN -- fractional seconds stored in 5.6
     SET @sql1 = '
@@ -406,6 +407,9 @@ SELECT tap.check_test(
 -- if othertab definition is changed or the _table_sha1() definition changed,
 -- rerun the tests with drop database disabled and recalculate sha1 in the database with
 -- SELECT tap._table_sha1('taptest','othertab');
+
+-- may require group_concat_max_len to be increased e.g.
+-- SET SESSION group_concat_max_len = 1000000;
 
 SELECT
    CASE WHEN tap.mysql_version() < 506000 THEN


### PR DESCRIPTION
Pre 5.7.6 global variables could be queried from information_schema, afterwards they are in performance_schema unless the version 56 compatibility mode is enabled. New file to reflect this change.

This also requires that we test for point versions in the test setup (will require same for install)