### PR TITLE
Added check for @@thread_stack limit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,9 +95,9 @@ MYVER=$(mysql ${MYSQLOPTS} --execute "
 
 thread_stack=$(mysql ${MYSQLOPTS} --execute "SELECT @@thread_stack" --skip_column_names)
 if [[ ${thread_stack} -lt 262144 ]]; then
-  echo "Your thread_stack variable is set to ${thread_stack} bytes what can"
-  echo "be too low to use myTAP. Consider changing thread stack variable to"
-  echo "at least 262144 bytes (add thread_stack=256k to your mysql.conf file)."
+  echo "Your thread_stack variable is set to ${thread_stack} bytes and will"
+  echo "be too low to use myTAP. You should change the thread_stack variable to"
+  echo "at least 262144 bytes (add thread_stack=256k to your mysql conf file)."
   exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,17 @@ MYVER=$(mysql ${MYSQLOPTS} --execute "
         + CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(VERSION(), '-', 1),'.', 3), '.', -1) AS UNSIGNED);
     ")
 
+# checking thread_stack settings. See #44 for reference.
+
+thread_stack=$(mysql ${MYSQLOPTS} --execute "SELECT @@thread_stack" --skip_column_names)
+if [[ ${thread_stack} -lt 262144 ]]; then
+  echo "Your thread_stack variable is set to ${thread_stack} bytes what can"
+  echo "be too low to use myTAP. Consider changing thread stack variable to"
+  echo "at least 262144 bytes (add thread_stack=256k to your mysql.conf file)."
+  exit 1
+fi
+
+
 # import the full package before running the tests
 # you can't use a wildcard with the source command so all version specific files need
 # to be separately listed


### PR DESCRIPTION
Added check for @@thread_stack limit (see #44).

Decided to break your coding convention a bit:
 - $() instead of backticks for execution
 - ${} istead of $ for variables

... but if that't not OK for you I can change it in fixup.

NB: There's no need to do awk magic in `./install`, as MySQL version number can be calculated using expression from `mysql_version`.

PS: Shouldn't there be `set -e` at the very beginning of `./install.sh`? In other words, should script go forward if any of commands failed?